### PR TITLE
INAV compatibility

### DIFF
--- a/src/blackbox/binary.rs
+++ b/src/blackbox/binary.rs
@@ -12,7 +12,7 @@ pub fn parse<T: Read + Seek>(stream: &mut T, _size: usize) -> Result<Vec<SampleI
     stream.read_to_end(&mut bytes)?;
 
     for index in memmem::find_iter(&bytes, b"H Product:Blackbox") {
-        if let Some(end) = memmem::find(&bytes[index..], b"End of log\0") {
+        if let Some(end) = memmem::find(&bytes[index..], b"End of log") {
             let log = &bytes[index..index+end+11];
 
             let mut bbox = fc_blackbox::BlackboxReader::from_bytes(log).unwrap();

--- a/src/blackbox/mod.rs
+++ b/src/blackbox/mod.rs
@@ -55,8 +55,8 @@ impl BlackBox {
                 "setpoint" | 
                 "motor" | 
                 "rcCommand" | 
-                "rcCommands" | 
-                "debug" => FieldType::Vector4(field[..pos].to_owned(), idx),
+                "rcCommands" => FieldType::Vector4(field[..pos].to_owned(), idx),
+                "debug" => FieldType::Vector8(field[..pos].to_owned(), idx),
 
                 _ => FieldType::Vector3(field[..pos].to_owned(), idx)
             }
@@ -116,6 +116,7 @@ impl BlackBox {
                 FieldType::Vector2(ref hdr, c) => { insert_entry!(c, hdr, Vec_TimeArray2_f64); }
                 FieldType::Vector3(ref hdr, c) => { insert_entry!(c, hdr, Vec_TimeVector3_f64); }
                 FieldType::Vector4(ref hdr, c) => { insert_entry!(c, hdr, Vec_TimeArray4_f64); }
+                FieldType::Vector8(ref hdr, c) => { insert_entry!(c, hdr, Vec_TimeArray8_f64); }
             }
         }
 
@@ -141,6 +142,10 @@ impl BlackBox {
                 0 => vec.get_mut().push(TimeArray4 { t: time, v: [val as f64, 0.0, 0.0, 0.0] }),
                 _ => vec.get_mut().last_mut().unwrap().v[i as usize] = val as f64,
             }
+            TagValue::Vec_TimeArray8_f64(vec) => match i {
+                0 => vec.get_mut().push(TimeArray8 { t: time, v: [val as f64, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0] }),
+                _ => vec.get_mut().last_mut().unwrap().v[i as usize] = val as f64,
+            }
             _ => { panic!("Unknown field type"); }
         }
     }
@@ -155,7 +160,8 @@ enum FieldType {
     Single(String),
     Vector2(String, u8),
     Vector3(String, u8),
-    Vector4(String, u8)
+    Vector4(String, u8),
+    Vector8(String, u8)
 }
 struct HeaderTagDesc {
     index: u8,

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -117,6 +117,7 @@ declare_types! {
     Vec_TimeVector3_i64f64: Vec<TimeVector3<i64, f64>>, 
     Vec_TimeQuaternion_f64: Vec<TimeQuaternion<f64>>, 
 
+    Vec_TimeArray8_f64: Vec<TimeArray8<f64>>,
     Vec_TimeArray4_f64: Vec<TimeArray4<f64>>, 
     Vec_TimeArray2_f64: Vec<TimeArray2<f64>>, 
 }

--- a/src/tags_impl.rs
+++ b/src/tags_impl.rs
@@ -259,6 +259,11 @@ impl<T: std::convert::Into<f64>> TimeVector3<T> {
     }
 }
 #[derive(Debug, Clone, Serialize, Default)]
+pub struct TimeArray8<T> {
+    pub t: f64,
+    pub v: [T; 8]
+}
+#[derive(Debug, Clone, Serialize, Default)]
 pub struct TimeArray4<T> {
     pub t: f64,
     pub v: [T; 4]


### PR DESCRIPTION
First of all, THANKS for the huge works done in GyroFlow.

I had some problems with INAV blackbox log in this tool, it didn't works, so i fixed them.

The INAV logs end with `End of log (disarm reason:4)`, so the string terminator here was a problem, i removed it:
https://github.com/AdrianEddy/telemetry-parser/blob/50a3d44cbc607dd864092a0506fec59bb363bf6f/src/blackbox/binary.rs#L15

The second problem was that the debug variables are 8, and not 4, so them cannot be putted in a Vector4, so i have created a Vector8.

This is a INAV 4.1 blackbox log if you like to do some tests
[inav_blackbox.zip](https://github.com/AdrianEddy/telemetry-parser/files/8008193/inav_blackbox.zip)

