### PR TITLE
Add support for ArduPilot .log format

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Work in progress, the code is already working but I plan to add much more input 
 - [x] WitMotion (WT901SDCL binary and *.txt)
 - [x] Mobile apps: `Sensor Logger`, `G-Field Recorder`, `Gyro`
 - [x] Gyroflow [.gcsv log](https://docs.gyroflow.xyz/logging/gcsv/)
+- [x] ArduPilot (*.log)
 - [ ] TODO DJI flight logs (*.dat, *.txt)
 
 # Example usage

--- a/src/ArduPilot/mod.rs
+++ b/src/ArduPilot/mod.rs
@@ -1,0 +1,87 @@
+use std::io::*;
+
+use crate::tags_impl::*;
+use crate::*;
+use memchr::memmem;
+
+#[derive(Default)]
+pub struct ArduPilot {
+    pub model: Option<String>
+}
+
+// ArduPilot .log format, not native .bin yet, .bin can be converted to .log using mission planner or https://github.com/ArduPilot/pymavlink/blob/master/tools/mavlogdump.py
+
+impl ArduPilot {
+
+    pub fn detect(buffer: &[u8], filename: &str) -> Option<Self> {
+        if !filename.ends_with(".log") { return None }
+
+        if memmem::find(buffer, b"FMT,").is_some() &&
+                memmem::find(buffer, b"PARM,").is_some() &&
+                memmem::find(buffer, b"VSTB,").is_some() {
+            return Some(Self { model: Some(".log".to_owned()) });
+        }
+        None
+    }
+
+    pub fn parse<T: Read + Seek>(&mut self, stream: &mut T, _size: usize) -> Result<Vec<SampleInfo>> {
+        let e = |_| -> Error { ErrorKind::InvalidData.into() };
+
+        let mut gyro = Vec::new();
+        let mut accl = Vec::new();
+
+        let mut csv = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .flexible(true)
+            .trim(csv::Trim::All)
+            .from_reader(stream);
+
+        let time_scale = 1.0e-6;
+        for row in csv.records() {
+            let row = row?;
+            if &row[0] != "VSTB" {
+                continue;
+            }
+            let time = row[1].parse::<f64>().map_err(e)? * time_scale;
+            gyro.push(TimeVector3 {
+                t: time,
+                x: row[2].parse::<f64>().map_err(e)?,
+                y: row[3].parse::<f64>().map_err(e)?,
+                z: row[4].parse::<f64>().map_err(e)?
+            });
+            accl.push(TimeVector3 {
+                t: time,
+                x: row[5].parse::<f64>().map_err(e)?,
+                y: row[6].parse::<f64>().map_err(e)?,
+                z: row[7].parse::<f64>().map_err(e)?
+            });
+        }
+
+        let mut map = GroupedTagMap::new();
+
+        util::insert_tag(&mut map, tag!(parsed GroupId::Accelerometer, TagId::Data, "Accelerometer data", Vec_TimeVector3_f64, |v| format!("{:?}", v), accl, vec![]));
+        util::insert_tag(&mut map, tag!(parsed GroupId::Gyroscope,     TagId::Data, "Gyroscope data",     Vec_TimeVector3_f64, |v| format!("{:?}", v), gyro, vec![]));
+
+        util::insert_tag(&mut map, tag!(parsed GroupId::Accelerometer, TagId::Unit, "Accelerometer unit", String, |v| v.to_string(), "m/s²".into(),  Vec::new()));
+        util::insert_tag(&mut map, tag!(parsed GroupId::Gyroscope,     TagId::Unit, "Gyroscope unit",     String, |v| v.to_string(), "rad/s".into(), Vec::new()));
+
+        util::insert_tag(&mut map, tag!(parsed GroupId::Gyroscope,     TagId::Scale, "Gyroscope scale",     f64, |v| format!("{:?}", v), 1.0, vec![]));
+        util::insert_tag(&mut map, tag!(parsed GroupId::Accelerometer, TagId::Scale, "Accelerometer scale", f64, |v| format!("{:?}", v), 1.0/9.81, vec![]));
+
+        let imu_orientation = "zyx";
+        util::insert_tag(&mut map, tag!(parsed GroupId::Accelerometer, TagId::Orientation, "IMU orientation", String, |v| v.to_string(), imu_orientation.into(), Vec::new()));
+        util::insert_tag(&mut map, tag!(parsed GroupId::Gyroscope,     TagId::Orientation, "IMU orientation", String, |v| v.to_string(), imu_orientation.into(), Vec::new()));
+    
+        Ok(vec![
+            SampleInfo { index: 0, timestamp_ms: 0.0, duration_ms: 0.0, tag_map: Some(map) }
+        ])
+    }
+
+    pub fn normalize_imu_orientation(v: String) -> String {
+        v
+    }
+    
+    pub fn camera_type(&self) -> String {
+        "ArduPilot".to_owned()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod runcam;
 mod witmotion;
 mod dji;
 mod phone_apps;
+mod ardupilot;
 
 pub mod tags_impl;
 pub mod util;
@@ -68,4 +69,5 @@ impl_formats! {
     WitMotion => witmotion::WitMotion,
     Dji       => dji::Dji,
     PhoneApps => phone_apps::PhoneApps,
+    ArduPilot => ardupilot::ArduPilot,
 }


### PR DESCRIPTION
My first go at Rust... so apologies if its all nonsense. 

This adds support for ArduPilot `.log` files. These are not the native format from the SD card, but are easy to generate with Mission Planner.

Seems to work but not extensively tested, I have one log and clip from @TMac54 that we tested on V0. 

This is the button in mission planner to get a `.log` from a `.bin`

![image](https://user-images.githubusercontent.com/33176108/153477663-8a123d57-f6a5-46cd-8b2f-ab09699129d5.png)

Would be nice to add support for `.bin` in the future, but there rather harder to parse.
