### PR TITLE
Add special handling of Insta360 X4 IMU orientation and camera center loading

### DIFF
--- a/src/insta360/mod.rs
+++ b/src/insta360/mod.rs
@@ -154,6 +154,7 @@ impl Insta360 {
                 Some("Insta360 GO Ultra") => "YxZ",
                 Some("Insta360 OneR")  => "Xyz",
                 Some("Insta360 OneRS") => "Xyz",
+                Some("Insta360 X4")    => "yzX",
                 _                      => "Xyz"
             }
         } else {
@@ -237,9 +238,10 @@ impl Insta360 {
             (offset_v3[0], offset_v3[1], offset_v3[2], offset_v3[3], offset_v3[4], offset_v3[5], offset_v3[6], offset_v3[7],
             offset_v3[8], offset_v3[9], offset_v3[10], offset_v3[11], offset_v3[12], offset_v3[13], offset_v3[14], offset_v3[15],
             offset_v3[16], offset_v3[17], offset_v3[18], offset_v3[19], offset_v3[20]);
-
+        
+        let cx_fix = if model == "X4" { 2.0 } else { 1.0 };  // X4: cx = 3987.5, w = 1920, lens_width = 16000.0, cy = 3012.7, h = 1920, lens_height = 6000.0
         let c_ratio = (
-            size.0 as f64 / lens_width,
+            size.0 as f64 / lens_width * cx_fix,
             size.1 as f64 / lens_height
         );
         let f_ratio = (
@@ -330,3 +332,4 @@ impl Insta360 {
         }
     }
 }
+


### PR DESCRIPTION
- IMU orientation changed: `Xyz` - > `yzX`
- `l.fisheye_params.camera_matrix[0][2]` (`cx`) doubled.

I haven't tested it.